### PR TITLE
fix(filerun/entrypoint): Install FileRun from tmp directory

### DIFF
--- a/filerun/entrypoint.sh
+++ b/filerun/entrypoint.sh
@@ -11,11 +11,11 @@ fi
 # Install FileRun on first run
 if [ ! -e /var/www/html/index.php ];  then
 	echo "[Downloading latest FileRun version]"
-  curl -o /filerun.zip -L 'https://filerun.com/download-latest-docker'
-	unzip -q /filerun.zip -d /var/www/html/
+  curl -o /tmp/filerun.zip -L 'https://filerun.com/download-latest-docker'
+	unzip -q /tmp/filerun.zip -d /var/www/html/
 	cp /filerun/overwrite_install_settings.temp.php /var/www/html/system/data/temp/
 	cp /filerun/.htaccess /var/www/html/
-	rm -f /filerun.zip
+	rm -f /tmp/filerun.zip
 	chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/html
 	chown ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /user-files
 	echo "Open this server in your browser to complete the FileRun installation."


### PR DESCRIPTION
it helps us to run FileRun on a read-only filesystem.